### PR TITLE
macOS file descriptor leak

### DIFF
--- a/winpr/libwinpr/synch/event.c
+++ b/winpr/libwinpr/synch/event.c
@@ -79,19 +79,16 @@ static BOOL EventCloseHandle_(WINPR_EVENT* event)
 	if (!event)
 		return FALSE;
 
-	if (!event->bAttached)
+	if (!event->bAttached && event->pipe_fd[0] != -1)
 	{
-		if (event->pipe_fd[0] != -1)
-		{
-			close(event->pipe_fd[0]);
-			event->pipe_fd[0] = -1;
-		}
+		close(event->pipe_fd[0]);
+		event->pipe_fd[0] = -1;
+	}
 
-		if (event->pipe_fd[1] != -1)
-		{
-			close(event->pipe_fd[1]);
-			event->pipe_fd[1] = -1;
-		}
+	if (event->pipe_fd[1] != -1)
+	{
+		close(event->pipe_fd[1]);
+		event->pipe_fd[1] = -1;
 	}
 
 	free(event->name);


### PR DESCRIPTION
`CreateEvent` on macOS uses `pipe`, creating a pair of file descriptors.

A call to `SetEventFileDescriptor` closes `fd[0]`, reassigns it to the incoming file descriptor, and marks the handle as "attached".

Then, in `CloseHandle`, we close both file descriptors only if not "attached" (i.e. they are owned by the event). This leaks `fd[1]`.

Since `fd[1]` is never reassigned, it's safe to simply check if it's valid and then close it.