### PR TITLE
FreeRDP fixes

### DIFF
--- a/DevolutionsRdp/DevolutionsRdp.c
+++ b/DevolutionsRdp/DevolutionsRdp.c
@@ -23,8 +23,8 @@ static BOOL cs_pre_connect(freerdp* instance);
 static BOOL cs_post_connect(freerdp* instance);
 static void cs_post_disconnect(freerdp* instance);
 static BOOL cs_authenticate(freerdp* instance, char** username, char** password, char** domain);
-static BOOL cs_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint);
-static int cs_verify_x509_certificate(freerdp* instance, BYTE* data, int length, const char* hostname, int port, DWORD flags);
+static DWORD cs_verify_certificate(freerdp* instance, const char* common_name, const char* subject, const char* issuer, const char* fingerprint, BOOL host_mismatch);
+static int cs_verify_x509_certificate(freerdp* instance, const BYTE* data, size_t length, const char* hostname, uint16_t port, DWORD flags);
 static char** freerdp_command_line_parse_comma_separated_values_offset(const char* name, char* list, size_t* count);
 static char** freerdp_command_line_parse_comma_separated_values_ex(const char* name, const char* list, size_t* count);
 void cs_error_info(void* ctx, ErrorInfoEventArgs* e);
@@ -422,12 +422,12 @@ static BOOL cs_authenticate(freerdp* instance, char** username, char** password,
 	return TRUE;
 }
 
-static BOOL cs_verify_certificate(freerdp* instance, char* subject, char* issuer, char* fingerprint)
+static DWORD cs_verify_certificate(freerdp* instance, const char* common_name, const char* subject, const char* issuer, const char* fingerprint, BOOL host_mismatch)
 {
 	return TRUE;
 }
 
-static int cs_verify_x509_certificate(freerdp* instance, BYTE* data, int length, const char* hostname, int port, DWORD flags)
+static int cs_verify_x509_certificate(freerdp* instance, const BYTE* data, size_t length, const char* hostname, uint16_t port, DWORD flags)
 {
 	return 1;
 }
@@ -688,7 +688,7 @@ BOOL csharp_freerdp_set_client_hostname(void* instance, const char* clientHostna
 BOOL csharp_freerdp_set_console_mode(void* instance, BOOL useConsoleMode, BOOL useRestrictedAdminMode)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->ConsoleSession = useConsoleMode;
 	settings->RestrictedAdminModeRequired = useRestrictedAdminMode;
@@ -699,7 +699,7 @@ BOOL csharp_freerdp_set_console_mode(void* instance, BOOL useConsoleMode, BOOL u
 BOOL csharp_freerdp_set_redirect_clipboard(void* instance, BOOL redirectClipboard)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->RedirectClipboard = redirectClipboard;
 
@@ -709,7 +709,7 @@ BOOL csharp_freerdp_set_redirect_clipboard(void* instance, BOOL redirectClipboar
 BOOL csharp_freerdp_set_redirect_audio(void* instance, int redirectSound, BOOL redirectCapture)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	char** p;
 	size_t count;
@@ -744,7 +744,7 @@ BOOL csharp_freerdp_set_redirect_audio(void* instance, int redirectSound, BOOL r
 BOOL csharp_freerdp_set_connection_info(void* instance, const char* hostname, const char* username, const char* password, const char* domain, UINT32 width, UINT32 height, UINT32 color_depth, UINT32 port, int codecLevel)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->DesktopWidth = width;
 	settings->DesktopHeight = height;
@@ -806,7 +806,7 @@ out_fail_strdup:
 BOOL csharp_freerdp_set_security_info(void* instance, BOOL useTLS, BOOL useNLA)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->RdpSecurity = TRUE;
 	settings->TlsSecurity = FALSE;
@@ -824,7 +824,7 @@ BOOL csharp_freerdp_set_security_info(void* instance, BOOL useTLS, BOOL useNLA)
 void csharp_freerdp_set_hyperv_info(void* instance, char* pcb)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->PreconnectionBlob = _strdup(pcb);
 	settings->VmConnectMode = TRUE;
@@ -836,7 +836,7 @@ void csharp_freerdp_set_hyperv_info(void* instance, char* pcb)
 void csharp_freerdp_set_keyboard_layout(void* instance, int layoutID)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->KeyboardLayout = layoutID;
 }
@@ -844,7 +844,7 @@ void csharp_freerdp_set_keyboard_layout(void* instance, int layoutID)
 void csharp_freerdp_set_redirect_all_drives(void* instance, BOOL redirect)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->RedirectDrives = redirect;
 }
@@ -852,7 +852,7 @@ void csharp_freerdp_set_redirect_all_drives(void* instance, BOOL redirect)
 void csharp_freerdp_set_redirect_home_drive(void* instance, BOOL redirect)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->RedirectHomeDrive = redirect;
 }
@@ -860,7 +860,7 @@ void csharp_freerdp_set_redirect_home_drive(void* instance, BOOL redirect)
 void csharp_freerdp_set_redirect_printers(void* instance, BOOL redirect)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->RedirectPrinters = redirect;
 }
@@ -868,7 +868,7 @@ void csharp_freerdp_set_redirect_printers(void* instance, BOOL redirect)
 void csharp_freerdp_set_redirect_smartcards(void* instance, BOOL redirect)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->RedirectSmartCards = redirect;
 }
@@ -876,7 +876,7 @@ void csharp_freerdp_set_redirect_smartcards(void* instance, BOOL redirect)
 BOOL csharp_freerdp_set_data_directory(void* instance, const char* directory)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->HomePath = settings->ConfigPath = NULL;
 
@@ -903,23 +903,23 @@ out_malloc_fail:
 void csharp_freerdp_set_alternate_shell(void* instance, const char* shell)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
-	settings->AlternateShell = (BYTE*)_strdup(shell);
+	settings->AlternateShell = _strdup(shell);
 }
 
 void csharp_freerdp_set_shell_working_directory(void* instance, const char* directory)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
-	settings->ShellWorkingDirectory = (BYTE*)_strdup(directory);
+	settings->ShellWorkingDirectory = _strdup(directory);
 }
 
 BOOL csharp_freerdp_set_scale_factor(void* instance, UINT32 desktopScaleFactor, UINT32 deviceScaleFactor)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->DesktopScaleFactor = desktopScaleFactor;
 	settings->DeviceScaleFactor = deviceScaleFactor;
@@ -1167,7 +1167,7 @@ void csharp_freerdp_redirect_drive(void* instance, char* name, char* path)
 void csharp_freerdp_set_smart_sizing(void* instance, bool smartSizing)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->SmartSizing = smartSizing;
 }
@@ -1175,7 +1175,7 @@ void csharp_freerdp_set_smart_sizing(void* instance, bool smartSizing)
 void csharp_freerdp_set_load_balance_info(void* instance, const char* info)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 
 	settings->LoadBalanceInfo = (BYTE*)_strdup(info);
 	settings->LoadBalanceInfoLength = (UINT32)strlen((char*) settings->LoadBalanceInfo);
@@ -1185,7 +1185,7 @@ BOOL csharp_freerdp_set_performance_flags(void* instance, BOOL disableWallpaper,
 					  BOOL bitmapCacheEnabled, BOOL disableFullWindowDrag, BOOL disableMenuAnims, BOOL disableThemes)
 {
 	freerdp* inst = (freerdp*)instance;
-	rdpSettings * settings = inst->settings;
+	rdpSettings* settings = inst->settings;
 	
 	settings->DisableWallpaper = disableWallpaper;
 	settings->AllowFontSmoothing = allowFontSmoothing;
@@ -1223,6 +1223,18 @@ void csharp_freerdp_sync_toggle_keys(void* instance)
 #endif
 }
 
+FREERDP_API BOOL csharp_freerdp_input_send_focus_in_event(void* instance, uint16_t toggleStates)
+{
+	rdpInput* input = ((freerdp*)instance)->input;
+	return freerdp_input_send_focus_in_event(input, toggleStates);
+}
+
+FREERDP_API BOOL csharp_freerdp_input_send_synchronize_event(void* instance, uint32_t flags)
+{
+	rdpInput* input = ((freerdp*)instance)->input;
+	return freerdp_input_send_synchronize_event(input, flags);
+}
+
 FREERDP_API void csharp_freerdp_create_virtual_channels(void* instance, const char* channelNames)
 {	
 	char *r, *end;
@@ -1230,7 +1242,7 @@ FREERDP_API void csharp_freerdp_create_virtual_channels(void* instance, const ch
 	char** p;
 	int status;
 	size_t count;
-	rdpSettings * settings = ((freerdp*)instance)->settings;
+	rdpSettings* settings = ((freerdp*)instance)->settings;
 
  	r = strdup(channelNames);
 

--- a/DevolutionsRdp/DevolutionsRdp.h
+++ b/DevolutionsRdp/DevolutionsRdp.h
@@ -19,7 +19,7 @@ typedef void (*fnOnDefaultCursor)(void* context);
 typedef struct csharp_context
 {
 	rdpContext _p;
-    
+
 	void* buffer;
 	HANDLE inputThread;
 	
@@ -33,7 +33,7 @@ typedef struct csharp_context
 	fnOnError onError;
 
 	fnOnChannelReceivedData onChannelReceivedData;
-	
+
 	BOOL clipboardSync;
 	wClipboard* clipboard;
 	UINT32 numServerFormats;
@@ -90,7 +90,8 @@ FREERDP_API void csharp_freerdp_set_hyperv_info(void* instance, char* pcb);
 FREERDP_API void csharp_freerdp_set_keyboard_layout(void* instance, int layoutID);
 FREERDP_API void csharp_freerdp_set_smart_sizing(void* instance, bool smartSizing);
 FREERDP_API void csharp_freerdp_sync_toggle_keys(void* instance);
-
+FREERDP_API BOOL csharp_freerdp_input_send_focus_in_event(void* instance, uint16_t toggleStates);
+FREERDP_API BOOL csharp_freerdp_input_send_synchronize_event(void* instance, uint32_t flags);
 FREERDP_API void csharp_set_on_authenticate(void* instance, pAuthenticate fn);
 FREERDP_API void csharp_set_on_clipboard_update(void* instance, fnOnClipboardUpdate fn);
 FREERDP_API void csharp_set_on_gateway_authenticate(void* instance, pAuthenticate fn);

--- a/DevolutionsRdp/clipboard.c
+++ b/DevolutionsRdp/clipboard.c
@@ -100,7 +100,7 @@ int cs_cliprdr_send_client_capabilities(CliprdrClientContext* cliprdr)
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_monitor_ready(CliprdrClientContext* cliprdr, CLIPRDR_MONITOR_READY* monitorReady)
+UINT cs_cliprdr_monitor_ready(CliprdrClientContext* cliprdr, const CLIPRDR_MONITOR_READY* monitorReady)
 {
 	csContext* ctx = (csContext*) cliprdr->custom;
 
@@ -116,7 +116,7 @@ UINT cs_cliprdr_monitor_ready(CliprdrClientContext* cliprdr, CLIPRDR_MONITOR_REA
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_capabilities(CliprdrClientContext* cliprdr, CLIPRDR_CAPABILITIES* capabilities)
+UINT cs_cliprdr_server_capabilities(CliprdrClientContext* cliprdr, const CLIPRDR_CAPABILITIES* capabilities)
 {
 	UINT32 index;
 	CLIPRDR_CAPABILITY_SET* capabilitySet;
@@ -145,7 +145,7 @@ UINT cs_cliprdr_server_capabilities(CliprdrClientContext* cliprdr, CLIPRDR_CAPAB
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_format_list(CliprdrClientContext* cliprdr, CLIPRDR_FORMAT_LIST* formatList)
+UINT cs_cliprdr_server_format_list(CliprdrClientContext* cliprdr, const CLIPRDR_FORMAT_LIST* formatList)
 {
 	UINT32 index;
 	CLIPRDR_FORMAT* format;
@@ -205,7 +205,7 @@ UINT cs_cliprdr_server_format_list(CliprdrClientContext* cliprdr, CLIPRDR_FORMAT
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_format_list_response(CliprdrClientContext* cliprdr, CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
+UINT cs_cliprdr_server_format_list_response(CliprdrClientContext* cliprdr, const CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
 	return CHANNEL_RC_OK;
 }
@@ -215,7 +215,7 @@ UINT cs_cliprdr_server_format_list_response(CliprdrClientContext* cliprdr, CLIPR
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_lock_clipboard_data(CliprdrClientContext* cliprdr, CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
+UINT cs_cliprdr_server_lock_clipboard_data(CliprdrClientContext* cliprdr, const CLIPRDR_LOCK_CLIPBOARD_DATA* lockClipboardData)
 {
 	return CHANNEL_RC_OK;
 }
@@ -225,7 +225,7 @@ UINT cs_cliprdr_server_lock_clipboard_data(CliprdrClientContext* cliprdr, CLIPRD
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_unlock_clipboard_data(CliprdrClientContext* cliprdr, CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
+UINT cs_cliprdr_server_unlock_clipboard_data(CliprdrClientContext* cliprdr, const CLIPRDR_UNLOCK_CLIPBOARD_DATA* unlockClipboardData)
 {
 	return CHANNEL_RC_OK;
 }
@@ -235,7 +235,7 @@ UINT cs_cliprdr_server_unlock_clipboard_data(CliprdrClientContext* cliprdr, CLIP
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_format_data_request(CliprdrClientContext* cliprdr, CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
+UINT cs_cliprdr_server_format_data_request(CliprdrClientContext* cliprdr, const CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
 {
 	BYTE* data;
 	UINT32 size;
@@ -271,7 +271,7 @@ UINT cs_cliprdr_server_format_data_request(CliprdrClientContext* cliprdr, CLIPRD
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_format_data_response(CliprdrClientContext* cliprdr, CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
+UINT cs_cliprdr_server_format_data_response(CliprdrClientContext* cliprdr, const CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
 {
 	BYTE* data;
 	UINT32 size;
@@ -320,7 +320,7 @@ UINT cs_cliprdr_server_format_data_response(CliprdrClientContext* cliprdr, CLIPR
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_file_contents_request(CliprdrClientContext* cliprdr, CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
+UINT cs_cliprdr_server_file_contents_request(CliprdrClientContext* cliprdr, const CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
 {
 	return CHANNEL_RC_OK;
 }
@@ -330,7 +330,7 @@ UINT cs_cliprdr_server_file_contents_request(CliprdrClientContext* cliprdr, CLIP
  *
  * @return 0 on success, otherwise a Win32 error code
  */
-UINT cs_cliprdr_server_file_contents_response(CliprdrClientContext* cliprdr, CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
+UINT cs_cliprdr_server_file_contents_response(CliprdrClientContext* cliprdr, const CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
 {
 	return CHANNEL_RC_OK;
 }

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -33,6 +33,8 @@
 
 #define TAG FREERDP_TAG("codec")
 
+#define ALIGN(val, align) ((val) % (align) == 0) ? (val) : ((val) + (align) - (val) % (align))
+
 static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* planar, BOOL alpha,
                                           UINT32 DstFormat)
 {
@@ -1483,8 +1485,8 @@ BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context, UINT32 
 		return FALSE;
 
 	context->bgr = FALSE;
-	context->maxWidth = width;
-	context->maxHeight = height;
+	context->maxWidth = ALIGN(width, 4);
+	context->maxHeight = ALIGN(height, 4);
 	context->maxPlaneSize = context->maxWidth * context->maxHeight;
 	context->nTempStep = context->maxWidth * 4;
 	free(context->planesBuffer);

--- a/winpr/libwinpr/input/keycode.c
+++ b/winpr/libwinpr/input/keycode.c
@@ -144,7 +144,7 @@ DWORD KEYCODE_TO_VKCODE_APPLE[256] = {
 	VK_F3,                /* APPLE_VK_F3 (0x63) */
 	VK_F8,                /* APPLE_VK_F8 (0x64) */
 	VK_F9,                /* APPLE_VK_F9 (0x65) */
-	0,                    /* APPLE_VK_JIS_Eisu (0x66) */
+	VK_ABNT_C1,           /* APPLE_VK_JIS_Eisu (0x66) */
 	VK_F11,               /* APPLE_VK_F11 (0x67) */
 	0,                    /* APPLE_VK_JIS_Kana (0x68) */
 	VK_SNAPSHOT | KBDEXT, /* APPLE_VK_F13 (0x69) */

--- a/winpr/libwinpr/input/keycode.c
+++ b/winpr/libwinpr/input/keycode.c
@@ -136,7 +136,7 @@ DWORD KEYCODE_TO_VKCODE_APPLE[256] = {
 	VK_NUMPAD8,           /* APPLE_VK_ANSI_Keypad8 (0x5B) */
 	VK_NUMPAD9,           /* APPLE_VK_ANSI_Keypad9 (0x5C) */
 	0,                    /* APPLE_VK_JIS_Yen (0x5D) */
-	0,                    /* APPLE_VK_JIS_Underscore (0x5E) */
+	VK_ABNT_C1,           /* APPLE_VK_JIS_Underscore (0x5E) */
 	VK_DECIMAL,           /* APPLE_VK_JIS_KeypadComma (0x5F) */
 	VK_F5,                /* APPLE_VK_F5 (0x60) */
 	VK_F6,                /* APPLE_VK_F6 (0x61) */
@@ -144,7 +144,7 @@ DWORD KEYCODE_TO_VKCODE_APPLE[256] = {
 	VK_F3,                /* APPLE_VK_F3 (0x63) */
 	VK_F8,                /* APPLE_VK_F8 (0x64) */
 	VK_F9,                /* APPLE_VK_F9 (0x65) */
-	VK_ABNT_C1,           /* APPLE_VK_JIS_Eisu (0x66) */
+	0,                    /* APPLE_VK_JIS_Eisu (0x66) */
 	VK_F11,               /* APPLE_VK_F11 (0x67) */
 	0,                    /* APPLE_VK_JIS_Kana (0x68) */
 	VK_SNAPSHOT | KBDEXT, /* APPLE_VK_F13 (0x69) */


### PR DESCRIPTION
- Fix callback signatures
- Expose `freerdp_input_send_focus_in_event` and `freerdp_input_send_synchronize_event` via DevolutionsRdp
- Add missing keycode mapping for `VK_ABNT_C1`
- Fix issues where with planar codec buffer alignment when width or height are not a multiple of 4