### PR TITLE
FreeRDP fixes

### DIFF
--- a/DevolutionsRdp/DevolutionsRdp.c
+++ b/DevolutionsRdp/DevolutionsRdp.c
@@ -1198,12 +1198,20 @@ BOOL csharp_freerdp_set_performance_flags(void* instance, BOOL disableWallpaper,
 	return TRUE;
 }
 
-FREERDP_API void csharp_freerdp_set_tcpacktimeout(void* instance, UINT32 value)
+void csharp_freerdp_set_tcpacktimeout(void* instance, UINT32 value)
 {
 	freerdp* inst = (freerdp*)instance;
 	rdpSettings* settings = inst->settings;
 
 	settings->TcpAckTimeout = value;
+}
+
+BOOL csharp_freerdp_set_value_for_name(void* instance, const char* name, const char* value)
+{
+	freerdp* inst = (freerdp*)instance;
+	rdpSettings* settings = inst->settings;
+
+	return freerdp_settings_set_value_for_name(settings, name, value);
 }
 
 void csharp_freerdp_sync_toggle_keys(void* instance)

--- a/DevolutionsRdp/DevolutionsRdp.c
+++ b/DevolutionsRdp/DevolutionsRdp.c
@@ -1198,6 +1198,14 @@ BOOL csharp_freerdp_set_performance_flags(void* instance, BOOL disableWallpaper,
 	return TRUE;
 }
 
+FREERDP_API void csharp_freerdp_set_tcpacktimeout(void* instance, UINT32 value)
+{
+	freerdp* inst = (freerdp*)instance;
+	rdpSettings* settings = inst->settings;
+
+	settings->TcpAckTimeout = value;
+}
+
 void csharp_freerdp_sync_toggle_keys(void* instance)
 {
 #ifdef WIN32

--- a/DevolutionsRdp/DevolutionsRdp.h
+++ b/DevolutionsRdp/DevolutionsRdp.h
@@ -11,10 +11,11 @@ typedef void (*fnRegionUpdated)(void* rdp, int x, int y, int width, int height);
 typedef void* (*fnDesktopSizeChanged)(void* rdp, int width, int height);
 typedef void (*fnOnError)(void* context, int code);
 typedef void (*fnOnClipboardUpdate)(void* context, byte* text, int length);
-typedef void (*fnOnNewCursor)(void* context, UINT32 id, BYTE* data, UINT32 x, UINT32 y, UINT32 w, UINT32 h, UINT32 hotX, UINT32 hotY);
+typedef void (*fnOnNewCursor)(void* context, void* pointer, BYTE* data, UINT32 x, UINT32 y, UINT32 w, UINT32 h, UINT32 hotX, UINT32 hotY);
 typedef BYTE* (*fnOnFreeCursor)(void* context, void* pointer);
 typedef void (*fnOnSetCursor)(void* context, void* pointer);
 typedef void (*fnOnDefaultCursor)(void* context);
+typedef BOOL (*fnOnAuthenticate)(void* context, char* pszUsername, int cchUsername, char* pszPassword, int cchPassword, char* pszDoman, int cchDomain);
 
 typedef struct csharp_context
 {
@@ -31,6 +32,8 @@ typedef struct csharp_context
 	fnOnSetCursor onSetCursor;
 	fnOnDefaultCursor onDefaultCursor;
 	fnOnError onError;
+	fnOnAuthenticate onAuthenticate;
+	fnOnAuthenticate onGwAuthenticate;
 
 	fnOnChannelReceivedData onChannelReceivedData;
 
@@ -47,6 +50,9 @@ typedef struct csharp_context
 	UINT32 clipboardCapabilities;
 } csContext;
 
+FREERDP_API BOOL csharp_configure_log_callback(int wlogLevel, wLogCallbackMessage_t fn);
+FREERDP_API BOOL csharp_configure_log_file(int wlogLevel, const char* logPath, const char* logName);
+
 FREERDP_API void* csharp_freerdp_new(void);
 FREERDP_API void csharp_freerdp_free(void* instance);
 FREERDP_API BOOL csharp_freerdp_connect(void* instance);
@@ -57,15 +63,15 @@ FREERDP_API void csharp_freerdp_set_initial_buffer(void* instance, void* buffer)
 FREERDP_API void csharp_freerdp_set_on_region_updated(void* instance, fnRegionUpdated fn);
 FREERDP_API void csharp_freerdp_set_on_desktop_size_changed(void* instance, fnDesktopSizeChanged fn);
 FREERDP_API BOOL csharp_freerdp_set_client_hostname(void* instance, const char* clientHostname);
-FREERDP_API BOOL csharp_freerdp_set_console_mode(void* instance, BOOL useConsoleMode, BOOL useRestrictedAdminMode);
-FREERDP_API BOOL csharp_freerdp_set_redirect_clipboard(void* instance, BOOL redirectClipboard);
+FREERDP_API void csharp_freerdp_set_console_mode(void* instance, BOOL useConsoleMode, BOOL useRestrictedAdminMode);
+FREERDP_API void csharp_freerdp_set_redirect_clipboard(void* instance, BOOL redirectClipboard);
 FREERDP_API BOOL csharp_freerdp_set_connection_info(void* instance, const char* hostname, const char* username, const char* password, const char* domain, UINT32 width, UINT32 height, UINT32 color_depth, UINT32 port, int codecLevel);
-FREERDP_API BOOL csharp_freerdp_set_security_info(void* instance, BOOL useTLS, BOOL useNLA);
+FREERDP_API void csharp_freerdp_set_security_info(void* instance, BOOL useTLS, BOOL useNLA);
 FREERDP_API BOOL csharp_freerdp_set_gateway_settings(void* instance, const char* hostname, UINT32 port, const char* username, const char* password, const char* domain, BOOL bypassLocal, BOOL httpTransport, BOOL rpcTransport);
 FREERDP_API BOOL csharp_freerdp_set_data_directory(void* instance, const char* directory);
 FREERDP_API void csharp_freerdp_set_load_balance_info(void* instance, const char* info);
-FREERDP_API BOOL csharp_freerdp_set_scale_factor(void* instance, UINT32 desktopScaleFactor, UINT32 deviceScaleFactor);
-FREERDP_API BOOL csharp_freerdp_set_performance_flags(void* instance,
+FREERDP_API void csharp_freerdp_set_scale_factor(void* instance, UINT32 desktopScaleFactor, UINT32 deviceScaleFactor);
+FREERDP_API void csharp_freerdp_set_performance_flags(void* instance,
 							   BOOL disableWallpaper,
 							   BOOL allowFontSmoothing,
 							   BOOL allowDesktopComposition,
@@ -79,8 +85,8 @@ FREERDP_API BOOL csharp_shall_disconnect(void* instance);
 FREERDP_API BOOL csharp_waitforsingleobject(void* instance);
 FREERDP_API BOOL csharp_check_event_handles(void* instance, void* buffer);
 
-
 FREERDP_API void csharp_freerdp_send_clipboard_data(void* instance, BYTE* data, int length);
+FREERDP_API void csharp_freerdp_send_clipboard_text(void* instance, const char* text);
 FREERDP_API void csharp_freerdp_send_cursor_event(void* instance, int x, int y, int flags);
 FREERDP_API void csharp_freerdp_send_input(void* instance, int keycode, BOOL down);
 FREERDP_API void csharp_freerdp_send_unicode(void* instance, int character);
@@ -88,16 +94,15 @@ FREERDP_API DWORD csharp_get_vk_from_keycode(DWORD keycode, DWORD flags);
 FREERDP_API DWORD csharp_get_scancode_from_vk(DWORD keycode, DWORD flags);
 FREERDP_API void csharp_freerdp_send_vkcode(void* instance, int vkcode, BOOL down);
 FREERDP_API void csharp_freerdp_send_scancode(void* instance, int flags, DWORD scancode);
-FREERDP_API void csharp_set_log_output(const char* path, const char* name);
 FREERDP_API void csharp_freerdp_set_hyperv_info(void* instance, char* pcb);
 FREERDP_API void csharp_freerdp_set_keyboard_layout(void* instance, int layoutID);
-FREERDP_API void csharp_freerdp_set_smart_sizing(void* instance, bool smartSizing);
+FREERDP_API void csharp_freerdp_set_smart_sizing(void* instance, BOOL smartSizing);
 FREERDP_API void csharp_freerdp_sync_toggle_keys(void* instance);
 FREERDP_API BOOL csharp_freerdp_input_send_focus_in_event(void* instance, uint16_t toggleStates);
 FREERDP_API BOOL csharp_freerdp_input_send_synchronize_event(void* instance, uint32_t flags);
-FREERDP_API void csharp_set_on_authenticate(void* instance, pAuthenticate fn);
+FREERDP_API void csharp_set_on_authenticate(void* instance, fnOnAuthenticate fn);
 FREERDP_API void csharp_set_on_clipboard_update(void* instance, fnOnClipboardUpdate fn);
-FREERDP_API void csharp_set_on_gateway_authenticate(void* instance, pAuthenticate fn);
+FREERDP_API void csharp_set_on_gateway_authenticate(void* instance, fnOnAuthenticate fn);
 FREERDP_API void csharp_set_on_verify_certificate(void* instance, pVerifyCertificate fn);
 FREERDP_API void csharp_set_on_verify_x509_certificate(void* instance, pVerifyX509Certificate fn);
 FREERDP_API void csharp_set_on_error(void* instance, fnOnError fn);
@@ -108,7 +113,7 @@ FREERDP_API int csharp_get_last_error(void* instance);
 FREERDP_API void csharp_freerdp_redirect_drive(void* instance, char* name, char* path);
 FREERDP_API void csharp_freerdp_set_redirect_all_drives(void* instance, BOOL redirect);
 FREERDP_API void csharp_freerdp_set_redirect_home_drive(void* instance, BOOL redirect);
-FREERDP_API BOOL csharp_freerdp_set_redirect_audio(void* instance, int redirectSound, BOOL redirectCapture);
+FREERDP_API void csharp_freerdp_set_redirect_audio(void* instance, int redirectSound, BOOL redirectCapture);
 FREERDP_API void csharp_freerdp_set_redirect_printers(void* instance, BOOL redirect);
 FREERDP_API void csharp_freerdp_set_redirect_smartcards(void* instance, BOOL redirect);
 

--- a/DevolutionsRdp/DevolutionsRdp.h
+++ b/DevolutionsRdp/DevolutionsRdp.h
@@ -73,9 +73,11 @@ FREERDP_API BOOL csharp_freerdp_set_performance_flags(void* instance,
 							   BOOL disableFullWindowDrag,
 							   BOOL disableMenuAnims,
 							   BOOL disableThemes);
+FREERDP_API void csharp_freerdp_set_tcpacktimeout(void* instance, UINT32 value);
 FREERDP_API BOOL csharp_shall_disconnect(void* instance);
 FREERDP_API BOOL csharp_waitforsingleobject(void* instance);
 FREERDP_API BOOL csharp_check_event_handles(void* instance, void* buffer);
+
 
 FREERDP_API void csharp_freerdp_send_clipboard_data(void* instance, BYTE* data, int length);
 FREERDP_API void csharp_freerdp_send_cursor_event(void* instance, int x, int y, int flags);

--- a/DevolutionsRdp/DevolutionsRdp.h
+++ b/DevolutionsRdp/DevolutionsRdp.h
@@ -74,6 +74,7 @@ FREERDP_API BOOL csharp_freerdp_set_performance_flags(void* instance,
 							   BOOL disableMenuAnims,
 							   BOOL disableThemes);
 FREERDP_API void csharp_freerdp_set_tcpacktimeout(void* instance, UINT32 value);
+FREERDP_API BOOL csharp_freerdp_set_value_for_name(void* settings, const char* name, const char* value);
 FREERDP_API BOOL csharp_shall_disconnect(void* instance);
 FREERDP_API BOOL csharp_waitforsingleobject(void* instance);
 FREERDP_API BOOL csharp_check_event_handles(void* instance, void* buffer);

--- a/DevolutionsRdp/cursor.c
+++ b/DevolutionsRdp/cursor.c
@@ -20,11 +20,11 @@ BOOL cs_Pointer_New(rdpContext* context, rdpPointer* pointer)
 	int pixelFormat = PIXEL_FORMAT_RGBA32;
 #endif
 	
-	if (freerdp_image_copy_from_pointer_data(cursor_data, pixelFormat,
+	if (!freerdp_image_copy_from_pointer_data(cursor_data, pixelFormat,
 						  pointer->width * 4, 0, 0, pointer->width, pointer->height,
 						  pointer->xorMaskData, pointer->lengthXorMask,
 						  pointer->andMaskData, pointer->lengthAndMask,
-						  pointer->xorBpp, NULL) < 0)
+						  pointer->xorBpp, NULL))
 	{
 		free(cursor_data);
 		return FALSE;
@@ -32,7 +32,9 @@ BOOL cs_Pointer_New(rdpContext* context, rdpPointer* pointer)
 	
 	if(csc->onNewCursor)
 	{
-		csc->onNewCursor(context->instance, pointer, cursor_data, pointer->xPos, pointer->yPos, pointer->width, pointer->height, pointer->xPos, pointer->yPos);
+		csc->onNewCursor(context->instance, pointer, cursor_data, 
+		  pointer->xPos, pointer->yPos, pointer->width, pointer->height, 
+		  pointer->xPos, pointer->yPos);
 	}
 	else
 	{

--- a/DevolutionsRdp/headless.c
+++ b/DevolutionsRdp/headless.c
@@ -9,33 +9,11 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#ifdef _WIN32
-
-void* csharp_create_shared_buffer(char* name, int size)
-{
-	HANDLE hMapFile;
-
-	hMapFile = CreateFileMapping(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, size, name);
-	
-	if (!hMapFile)
-		return NULL;
-
-	return hMapFile;
-}
-
-void csharp_destroy_shared_buffer(void* hMapFile)
-{
-	if (hMapFile)
-		CloseHandle(hMapFile);
-}
-
-#else
-
-bool csharp_create_shared_buffer(char* name, int size)
+BOOL csharp_create_shared_buffer(char* name, int size)
 {
 	BOOL result = FALSE;
 
-#if !defined(ANDROID) && !defined(IOS)
+#if !defined(ANDROID) && !defined(IOS) && !defined(_WIN32)
 	int desc = shm_open(name, O_RDWR | O_CREAT | O_EXCL, 0600);
 	
 	if(desc < 0)
@@ -53,10 +31,8 @@ bool csharp_create_shared_buffer(char* name, int size)
 
 void csharp_destroy_shared_buffer(char* name)
 {
-#if !defined(ANDROID) && !defined(IOS)
+#if !defined(ANDROID) && !defined(IOS) && !defined(_WIN32)
 	//munmap(buffer, size);
 	shm_unlink(name);
 #endif
 }
-
-#endif

--- a/DevolutionsRdp/headless.h
+++ b/DevolutionsRdp/headless.h
@@ -3,11 +3,7 @@
 
 #include <freerdp/api.h>
 
-FREERDP_API void* csharp_create_shared_buffer(char* name, int size);
-#ifdef _WIN32
-FREERDP_API void csharp_destroy_shared_buffer(void* hMapFile);
-#else
+FREERDP_API BOOL csharp_create_shared_buffer(char* name, int size);
 FREERDP_API void csharp_destroy_shared_buffer(char* name);
-#endif
 
 #endif /* CS_HEADLESS_H_ */

--- a/channels/audin/client/CMakeLists.txt
+++ b/channels/audin/client/CMakeLists.txt
@@ -41,6 +41,10 @@ if(WITH_ALSA)
 	add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "alsa" "")
 endif()
 
+if(WITH_IOSAUDIO)
+	add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "ios" "")
+endif()
+
 if(WITH_PULSE)
 	add_channel_client_subsystem(${MODULE_PREFIX} ${CHANNEL_NAME} "pulse" "")
 endif()

--- a/channels/audin/client/audin_main.c
+++ b/channels/audin/client/audin_main.c
@@ -977,6 +977,9 @@ UINT DVCPluginEntry(IDRDYNVC_ENTRY_POINTS* pEntryPoints)
 	AUDIN_PLUGIN* audin;
 	struct SubsystemEntry entries[] =
 	{
+#if defined(WITH_IOSAUDIO)
+		{ "ios", "" },
+#endif
 #if defined(WITH_PULSE)
 		{ "pulse", "" },
 #endif

--- a/channels/audin/client/ios/CMakeLists.txt
+++ b/channels/audin/client/ios/CMakeLists.txt
@@ -1,9 +1,8 @@
 # FreeRDP: A Remote Desktop Protocol Implementation
 # FreeRDP cmake build script
 #
-# Copyright 2012 Laxmikant Rashinkar <LK.Rashinkar@gmail.com>
-# Copyright 2012 Marc-Andre Moreau <marcandre.moreau@gmail.com>
-# Copyright 2013 Corey Clayton <can.of.tuna@gmail.com>
+# Copyright (c) 2015 Armin Novak <armin.novak@thincast.com>
+# Copyright (c) 2015 Thincast Technologies GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,31 +16,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-define_channel_client_subsystem("rdpsnd" "mac" "")
-
-find_library(COCOA_LIBRARY Cocoa REQUIRED)
-FIND_LIBRARY(CORE_FOUNDATION CoreFoundation)
-FIND_LIBRARY(CORE_AUDIO CoreAudio REQUIRED)
-FIND_LIBRARY(AUDIO_TOOL AudioToolbox REQUIRED)
-FIND_LIBRARY(AV_FOUNDATION AVFoundation REQUIRED)
+define_channel_client_subsystem("audin" "ios" "")
+FIND_LIBRARY(CORE_AUDIO CoreAudio)
+FIND_LIBRARY(AVFOUNDATION AVFoundation)
+FIND_LIBRARY(AUDIO_TOOL AudioToolbox)
 
 set(${MODULE_PREFIX}_SRCS
-	rdpsnd_mac.m)
+	audin_ios.m)
 
 include_directories(..)
-include_directories(${MACAUDIO_INCLUDE_DIRS})
+include_directories(${MAC_INCLUDE_DIRS})
 
 add_channel_client_subsystem_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} "" TRUE "")
 
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} 
-    ${AUDIO_TOOL}
-    ${AV_FOUNDATION}
-    ${CORE_AUDIO}
-    ${COCOA_LIBRARY}
-    ${CORE_FOUNDATION})
-
-set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} freerdp winpr)
+set(${MODULE_PREFIX}_LIBS freerdp ${AVFOUNDATION} ${CORE_AUDIO} ${AUDIO_TOOL} winpr)
 
 target_link_libraries(${MODULE_NAME} ${${MODULE_PREFIX}_LIBS})
-
-set_property(TARGET ${MODULE_NAME} PROPERTY FOLDER "Channels/${CHANNEL_NAME}/Client/Mac")

--- a/channels/audin/client/ios/audin_ios.m
+++ b/channels/audin/client/ios/audin_ios.m
@@ -1,0 +1,341 @@
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * Audio Input Redirection Virtual Channel - iOS implementation
+ *
+ * Copyright (c) 2015 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2015 Thincast Technologies GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <winpr/crt.h>
+#include <winpr/synch.h>
+#include <winpr/string.h>
+#include <winpr/thread.h>
+#include <winpr/debug.h>
+#include <winpr/cmdline.h>
+
+#import <AVFoundation/AVFoundation.h>
+
+#define __COREFOUNDATION_CFPLUGINCOM__ 1
+#define IUNKNOWN_C_GUTS   \
+	void *_reserved;      \
+	void *QueryInterface; \
+	void *AddRef;         \
+	void *Release
+
+#include <CoreAudio/CoreAudioTypes.h>
+#include <AudioToolbox/AudioToolbox.h>
+#include <AudioToolbox/AudioQueue.h>
+
+#include <freerdp/addin.h>
+#include <freerdp/channels/rdpsnd.h>
+
+#include "audin_main.h"
+
+#define IOS_AUDIO_QUEUE_NUM_BUFFERS 100
+
+typedef struct _AudinIosDevice
+{
+	IAudinDevice iface;
+
+	AUDIO_FORMAT format;
+	UINT32 FramesPerPacket;
+	int dev_unit;
+
+	AudinReceive receive;
+	void *user_data;
+
+	rdpContext *rdpcontext;
+
+	bool isOpen;
+	AudioQueueRef audioQueue;
+	AudioStreamBasicDescription audioFormat;
+	AudioQueueBufferRef audioBuffers[IOS_AUDIO_QUEUE_NUM_BUFFERS];
+} AudinIosDevice;
+
+static AudioFormatID audin_ios_get_format(const AUDIO_FORMAT *format)
+{
+	switch (format->wFormatTag)
+	{
+		case WAVE_FORMAT_PCM:
+			return kAudioFormatLinearPCM;
+
+		default:
+			return 0;
+	}
+}
+
+static AudioFormatFlags audin_ios_get_flags_for_format(const AUDIO_FORMAT *format)
+{
+	switch (format->wFormatTag)
+	{
+		case WAVE_FORMAT_PCM:
+			return kAudioFormatFlagIsSignedInteger;
+
+		default:
+			return 0;
+	}
+}
+
+static BOOL audin_ios_format_supported(IAudinDevice *device, const AUDIO_FORMAT *format)
+{
+	AudinIosDevice *ios = (AudinIosDevice *)device;
+	AudioFormatID req_fmt = 0;
+
+	if (device == NULL || format == NULL)
+		return FALSE;
+
+	req_fmt = audin_ios_get_format(format);
+
+	if (req_fmt == 0)
+		return FALSE;
+
+	return TRUE;
+}
+
+/**
+ * Function description
+ *
+ * @return 0 on success, otherwise a Win32 error code
+ */
+static UINT audin_ios_set_format(IAudinDevice *device, const AUDIO_FORMAT *format,
+                                 UINT32 FramesPerPacket)
+{
+	AudinIosDevice *ios = (AudinIosDevice *)device;
+
+	if (device == NULL || format == NULL)
+		return ERROR_INVALID_PARAMETER;
+
+	ios->FramesPerPacket = FramesPerPacket;
+	ios->format = *format;
+	WLog_INFO(TAG, "Audio Format %s [channels=%d, samples=%d, bits=%d]",
+	          audio_format_get_tag_string(format->wFormatTag), format->nChannels,
+	          format->nSamplesPerSec, format->wBitsPerSample);
+	ios->audioFormat.mBitsPerChannel = format->wBitsPerSample;
+
+	if (format->wBitsPerSample == 0)
+		ios->audioFormat.mBitsPerChannel = 16;
+	
+	ios->audioFormat.mChannelsPerFrame = ios->format.nChannels;
+	ios->audioFormat.mFramesPerPacket = 1;
+
+	ios->audioFormat.mBytesPerFrame = ios->audioFormat.mChannelsPerFrame * (ios->audioFormat.mBitsPerChannel / 8);
+	ios->audioFormat.mBytesPerPacket = ios->audioFormat.mBytesPerFrame * ios->audioFormat.mFramesPerPacket;
+	
+	ios->audioFormat.mFormatFlags = audin_ios_get_flags_for_format(format);
+	ios->audioFormat.mFormatID = audin_ios_get_format(format);
+	ios->audioFormat.mReserved = 0;
+	ios->audioFormat.mSampleRate = ios->format.nSamplesPerSec;
+	return CHANNEL_RC_OK;
+}
+
+static void ios_audio_queue_input_cb(void *aqData, AudioQueueRef inAQ, AudioQueueBufferRef inBuffer,
+                                     const AudioTimeStamp *inStartTime, UInt32 inNumPackets,
+                                     const AudioStreamPacketDescription *inPacketDesc)
+{
+	AudinIosDevice *ios = (AudinIosDevice *)aqData;
+	UINT error = CHANNEL_RC_OK;
+	const BYTE *buffer = inBuffer->mAudioData;
+	int buffer_size = inBuffer->mAudioDataByteSize;
+	(void)inAQ;
+	(void)inStartTime;
+	(void)inNumPackets;
+	(void)inPacketDesc;
+
+	if (buffer_size > 0)
+		error = ios->receive(&ios->format, buffer, buffer_size, ios->user_data);
+
+	AudioQueueEnqueueBuffer(inAQ, inBuffer, 0, NULL);
+
+	if (error)
+	{
+		WLog_ERR(TAG, "ios->receive failed with error %" PRIu32 "", error);
+		SetLastError(ERROR_INTERNAL_ERROR);
+	}
+}
+
+static UINT audin_ios_close(IAudinDevice *device)
+{
+	UINT errCode = CHANNEL_RC_OK;
+	char errString[1024];
+	OSStatus devStat;
+	AudinIosDevice *ios = (AudinIosDevice *)device;
+
+	if (device == NULL)
+		return ERROR_INVALID_PARAMETER;
+
+	if (ios->isOpen)
+	{
+		devStat = AudioQueueStop(ios->audioQueue, true);
+
+		if (devStat != 0)
+		{
+			errCode = GetLastError();
+			WLog_ERR(TAG, "AudioQueueStop failed with %s [%" PRIu32 "]",
+			         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+		}
+
+		ios->isOpen = false;
+	}
+
+	if (ios->audioQueue)
+	{
+		devStat = AudioQueueDispose(ios->audioQueue, true);
+
+		if (devStat != 0)
+		{
+			errCode = GetLastError();
+			WLog_ERR(TAG, "AudioQueueDispose failed with %s [%" PRIu32 "]",
+			         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+		}
+
+		ios->audioQueue = NULL;
+	}
+
+	ios->receive = NULL;
+	ios->user_data = NULL;
+	return errCode;
+}
+
+static UINT audin_ios_open(IAudinDevice *device, AudinReceive receive, void *user_data)
+{
+	AudinIosDevice *ios = (AudinIosDevice *)device;
+	DWORD errCode;
+	char errString[1024];
+	OSStatus devStat;
+	size_t index;
+
+	ios->receive = receive;
+	ios->user_data = user_data;
+	devStat = AudioQueueNewInput(&(ios->audioFormat), ios_audio_queue_input_cb, ios, NULL,
+	                             kCFRunLoopCommonModes, 0, &(ios->audioQueue));
+
+	if (devStat != 0)
+	{
+		errCode = GetLastError();
+		WLog_ERR(TAG, "AudioQueueNewInput failed with %s [%" PRIu32 "]",
+		         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+		goto err_out;
+	}
+
+	for (index = 0; index < IOS_AUDIO_QUEUE_NUM_BUFFERS; index++)
+	{
+		devStat = AudioQueueAllocateBuffer(ios->audioQueue,
+		                                   ios->FramesPerPacket * 2 * ios->format.nChannels,
+		                                   &ios->audioBuffers[index]);
+
+		if (devStat != 0)
+		{
+			errCode = GetLastError();
+			WLog_ERR(TAG, "AudioQueueAllocateBuffer failed with %s [%" PRIu32 "]",
+			         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+			goto err_out;
+		}
+
+		devStat = AudioQueueEnqueueBuffer(ios->audioQueue, ios->audioBuffers[index], 0, NULL);
+
+		if (devStat != 0)
+		{
+			errCode = GetLastError();
+			WLog_ERR(TAG, "AudioQueueEnqueueBuffer failed with %s [%" PRIu32 "]",
+			         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+			goto err_out;
+		}
+	}
+
+	devStat = AudioQueueStart(ios->audioQueue, NULL);
+
+	if (devStat != 0)
+	{
+		errCode = GetLastError();
+		WLog_ERR(TAG, "AudioQueueStart failed with %s [%" PRIu32 "]",
+		         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+		goto err_out;
+	}
+
+	ios->isOpen = true;
+	return CHANNEL_RC_OK;
+err_out:
+	audin_ios_close(device);
+	return CHANNEL_RC_INITIALIZATION_ERROR;
+}
+
+static UINT audin_ios_free(IAudinDevice *device)
+{
+	AudinIosDevice *ios = (AudinIosDevice *)device;
+	int error;
+
+	if (device == NULL)
+		return ERROR_INVALID_PARAMETER;
+
+	if ((error = audin_ios_close(device)))
+	{
+		WLog_ERR(TAG, "audin_oss_close failed with error code %d!", error);
+	}
+
+	free(ios);
+	return CHANNEL_RC_OK;
+}
+
+#ifdef BUILTIN_CHANNELS
+#define freerdp_audin_client_subsystem_entry ios_freerdp_audin_client_subsystem_entry
+#else
+#define freerdp_audin_client_subsystem_entry FREERDP_API freerdp_audin_client_subsystem_entry
+#endif
+
+UINT freerdp_audin_client_subsystem_entry(PFREERDP_AUDIN_DEVICE_ENTRY_POINTS pEntryPoints)
+{
+	DWORD errCode;
+	char errString[1024];
+	const ADDIN_ARGV *args;
+	AudinIosDevice *ios;
+	UINT error;
+	ios = (AudinIosDevice *)calloc(1, sizeof(AudinIosDevice));
+
+	if (!ios)
+	{
+		errCode = GetLastError();
+		WLog_ERR(TAG, "calloc failed with %s [%" PRIu32 "]",
+		         winpr_strerror(errCode, errString, sizeof(errString)), errCode);
+		return CHANNEL_RC_NO_MEMORY;
+	}
+
+	ios->iface.Open = audin_ios_open;
+	ios->iface.FormatSupported = audin_ios_format_supported;
+	ios->iface.SetFormat = audin_ios_set_format;
+	ios->iface.Close = audin_ios_close;
+	ios->iface.Free = audin_ios_free;
+	ios->rdpcontext = pEntryPoints->rdpcontext;
+	ios->dev_unit = -1;
+	args = pEntryPoints->args;
+
+	if ((error = pEntryPoints->pRegisterAudinDevice(pEntryPoints->plugin, (IAudinDevice *)ios)))
+	{
+		WLog_ERR(TAG, "RegisterAudinDevice failed with error %" PRIu32 "!", error);
+		goto error_out;
+	}
+
+	return CHANNEL_RC_OK;
+error_out:
+	free(ios);
+	return error;
+}

--- a/channels/audin/client/mac/audin_mac.m
+++ b/channels/audin/client/mac/audin_mac.m
@@ -153,13 +153,15 @@ static UINT audin_mac_set_format(IAudinDevice *device, const AUDIO_FORMAT *forma
 
 	if (format->wBitsPerSample == 0)
 		mac->audioFormat.mBitsPerChannel = 16;
-
-	mac->audioFormat.mBytesPerFrame = 0;
-	mac->audioFormat.mBytesPerPacket = 0;
+	
 	mac->audioFormat.mChannelsPerFrame = mac->format.nChannels;
+	mac->audioFormat.mFramesPerPacket = 1;
+
+	mac->audioFormat.mBytesPerFrame = mac->audioFormat.mChannelsPerFrame * (mac->audioFormat.mBitsPerChannel / 8);
+	mac->audioFormat.mBytesPerPacket = mac->audioFormat.mBytesPerFrame * mac->audioFormat.mFramesPerPacket;
+	
 	mac->audioFormat.mFormatFlags = audin_mac_get_flags_for_format(format);
 	mac->audioFormat.mFormatID = audin_mac_get_format(format);
-	mac->audioFormat.mFramesPerPacket = 1;
 	mac->audioFormat.mReserved = 0;
 	mac->audioFormat.mSampleRate = mac->format.nSamplesPerSec;
 	return CHANNEL_RC_OK;

--- a/channels/rdpsnd/client/ios/CMakeLists.txt
+++ b/channels/rdpsnd/client/ios/CMakeLists.txt
@@ -31,8 +31,6 @@ include_directories(..)
 
 add_channel_client_subsystem_library(${MODULE_PREFIX} ${MODULE_NAME} ${CHANNEL_NAME} "" TRUE "")
 
-
-
 set(${MODULE_PREFIX}_LIBS ${${MODULE_PREFIX}_LIBS} 
     ${AUDIO_TOOL}
     ${CORE_AUDIO}

--- a/channels/rdpsnd/client/ios/rdpsnd_ios.c
+++ b/channels/rdpsnd/client/ios/rdpsnd_ios.c
@@ -85,7 +85,7 @@ static OSStatus rdpsnd_ios_render_cb(void* inRefCon,
 	return noErr;
 }
 
-static BOOL rdpsnd_ios_format_supported(rdpsndDevicePlugin* __unused device, AUDIO_FORMAT* format)
+static bool rdpsnd_ios_format_supported(rdpsndDevicePlugin* __unused device, const AUDIO_FORMAT* format)
 {
 	if (format->wFormatTag == WAVE_FORMAT_PCM)
 	{
@@ -140,7 +140,7 @@ static void rdpsnd_ios_stop(rdpsndDevicePlugin* __unused device)
 	}
 }
 
-static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, BYTE* data, int size)
+static unsigned int rdpsnd_ios_play(rdpsndDevicePlugin* device, const unsigned char* data, unsigned long size)
 {
 	rdpsndIOSPlugin* p = THIS(device);
 	const BOOL ok = TPCircularBufferProduceBytes(&p->buffer, data, size);
@@ -152,7 +152,7 @@ static UINT rdpsnd_ios_play(rdpsndDevicePlugin* device, BYTE* data, int size)
 	return 10; /* TODO: Get real latencry in [ms] */
 }
 
-static BOOL rdpsnd_ios_open(rdpsndDevicePlugin* device, AUDIO_FORMAT* format, int __unused latency)
+static bool rdpsnd_ios_open(rdpsndDevicePlugin* device, const AUDIO_FORMAT* format, unsigned int __unused latency)
 {
 	rdpsndIOSPlugin* p = THIS(device);
 

--- a/channels/rdpsnd/client/ios/rdpsnd_ios.c
+++ b/channels/rdpsnd/client/ios/rdpsnd_ios.c
@@ -285,7 +285,6 @@ UINT freerdp_rdpsnd_client_subsystem_entry(PFREERDP_RDPSND_DEVICE_ENTRY_POINTS p
 
 	p->device.Open = rdpsnd_ios_open;
 	p->device.FormatSupported = rdpsnd_ios_format_supported;
-	p->device.SetFormat = rdpsnd_ios_set_format;
 	p->device.SetVolume = rdpsnd_ios_set_volume;
 	p->device.Play = rdpsnd_ios_play;
 	p->device.Start = rdpsnd_ios_start;

--- a/libfreerdp/codec/planar.c
+++ b/libfreerdp/codec/planar.c
@@ -33,7 +33,7 @@
 
 #define TAG FREERDP_TAG("codec")
 
-#define ALIGN(val, align) ((val) % (align) == 0) ? (val) : ((val) + (align) - (val) % (align))
+#define _ALIGN(val, align) ((val) % (align) == 0) ? (val) : ((val) + (align) - (val) % (align))
 
 static INLINE UINT32 planar_invert_format(BITMAP_PLANAR_CONTEXT* planar, BOOL alpha,
                                           UINT32 DstFormat)
@@ -1485,8 +1485,8 @@ BOOL freerdp_bitmap_planar_context_reset(BITMAP_PLANAR_CONTEXT* context, UINT32 
 		return FALSE;
 
 	context->bgr = FALSE;
-	context->maxWidth = ALIGN(width, 4);
-	context->maxHeight = ALIGN(height, 4);
+	context->maxWidth = _ALIGN(width, 4);
+	context->maxHeight = _ALIGN(height, 4);
 	context->maxPlaneSize = context->maxWidth * context->maxHeight;
 	context->nTempStep = context->maxWidth * 4;
 	free(context->planesBuffer);

--- a/winpr/include/winpr/wtypes.h.in
+++ b/winpr/include/winpr/wtypes.h.in
@@ -162,6 +162,7 @@ typedef void* PVOID, *LPVOID, *PVOID64, *LPVOID64;
 typedef __int32 BOOL;
 #else /* __APPLE__ */
 /* ensure compatibility with objc libraries */
+#include <TargetConditionals.h>
 #if (TARGET_OS_IPHONE && __LP64__)  ||  TARGET_OS_WATCH
 typedef bool BOOL;
 #else


### PR DESCRIPTION
I updated and made small fixes to DevolutionsRdp. The main interesting changes are:

- Remove the "shared buffer" implementation for Windows. It's not used, and is likely broken (e.g. it calls `CreateFileMapping` and passes a C string). It also leads to a confusing interface (the header contained the Windows functions, which have a different signature).
-  Added the `audin` channel for iOS. It's essentially a copy-paste of the macOS implementation with some small changes. I omitted handling of the microphone permission, since managing the UI prompt is something better done by the application.
- Fixed the `audin` channel for macOS to work properly under macOS 12 Monterey.
- I reworked the `Authenticate` handler in the bindings. Why? The existing callback passes string pointers up to the application. If the application wants to rewrite the strings, it's expect to `free` the existing values, and then allocate new memory. Even if we don't `free` the existing values and just leak the memory (as some clients do), the allocation is problematic - currently, the bindings handle this automagically by marshalling `string` in the P/Invoke declaration. It's obviously wrong, since the marshaller will copy the strings and then deallocate the memory again once the function returns. The callbacks aren't wrapped at all on the C# side, so we can't handle this with a higher-level API currently (although it's a goal for future improvement). Instead, I pass string buffers into the callback that the client can rewrite if needed (with some judicious extension methods for managing C strings, it's not too bad on the C# side). The buffers are sized according to the Windows CredUI, which seems reasonable