### PR TITLE
Specify security package type that will be used through CLI

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -1731,6 +1731,11 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 			if (!freerdp_settings_set_string(settings, FreeRDP_SspiModule, arg->Value))
 				return COMMAND_LINE_ERROR_MEMORY;
 		}
+		CommandLineSwitchCase(arg, "sspi-security-package")
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_SspiSecurityPackageName, arg->Value))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
 		CommandLineSwitchCase(arg, "redirect-prefer")
 		{
 			size_t count = 0;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -353,6 +353,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "SSH Agent forwarding channel" },
 	{ "sspi-module", COMMAND_LINE_VALUE_REQUIRED, "<SSPI module path>", NULL, NULL, -1, NULL,
 	  "SSPI shared library module file path" },
+	{ "sspi-security-package", COMMAND_LINE_VALUE_REQUIRED, "<SSPI security package name>", NULL, NULL, -1, NULL,
+	  "SSPI security package name which sspi-module supports. Default name is 'Negotiate'" },
 	{ "disable-output", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 	  "Deactivate all graphics decoding in the client session. Useful for load tests with many "
 	  "simultaneous connections" },

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -353,7 +353,7 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "SSH Agent forwarding channel" },
 	{ "sspi-module", COMMAND_LINE_VALUE_REQUIRED, "<SSPI module path>", NULL, NULL, -1, NULL,
 	  "SSPI shared library module file path" },
-	{ "sspi-security-package", COMMAND_LINE_VALUE_REQUIRED, "<SSPI security package name>", NULL, NULL, -1, NULL,
+	{ "sspi-security-package", COMMAND_LINE_VALUE_OPTIONAL, "<SSPI security package name>", NULL, NULL, -1, NULL,
 	  "SSPI security package name which sspi-module supports. Default name is 'Negotiate'" },
 	{ "disable-output", COMMAND_LINE_VALUE_FLAG, NULL, NULL, NULL, -1, NULL,
 	  "Deactivate all graphics decoding in the client session. Useful for load tests with many "

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -633,6 +633,7 @@ typedef struct
 #define FreeRDP_FIPSMode (1104)
 #define FreeRDP_TlsSecLevel (1105)
 #define FreeRDP_SspiModule (1106)
+#define FreeRDP_SspiSecurityPackageName (1107)
 #define FreeRDP_MstscCookieMode (1152)
 #define FreeRDP_CookieMaxLength (1153)
 #define FreeRDP_PreconnectionId (1154)
@@ -1115,7 +1116,8 @@ struct rdp_settings
 	ALIGN64 BOOL FIPSMode;                     /* 1104 */
 	ALIGN64 UINT32 TlsSecLevel;                /* 1105 */
 	ALIGN64 char* SspiModule;                  /* 1106 */
-	UINT64 padding1152[1152 - 1107];           /* 1107 */
+	ALIGN64 char* SspiSecurityPackageName;     /* 1107 */
+	UINT64 padding1152[1152 - 1108];           /* 1108 */
 
 	/* Connection Cookie */
 	ALIGN64 BOOL MstscCookieMode;      /* 1152 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2556,6 +2556,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_SspiModule:
 			return settings->SspiModule;
 
+		case FreeRDP_SspiSecurityPackageName:
+			return settings->SspiSecurityPackageName;
+
 		case FreeRDP_TargetNetAddress:
 			return settings->TargetNetAddress;
 
@@ -2816,6 +2819,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 
 		case FreeRDP_SspiModule:
 			return settings->SspiModule;
+
+		case FreeRDP_SspiSecurityPackageName:
+			return settings->SspiSecurityPackageName;
 
 		case FreeRDP_TargetNetAddress:
 			return settings->TargetNetAddress;
@@ -3087,6 +3093,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, const char* 
 
 		case FreeRDP_SspiModule:
 			return update_string(&settings->SspiModule, cnv.cc, len, cleanup);
+
+		case FreeRDP_SspiSecurityPackageName:
+			return update_string(&settings->SspiSecurityPackageName, cnv.cc, len, cleanup);
 
 		case FreeRDP_TargetNetAddress:
 			return update_string(&settings->TargetNetAddress, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -385,6 +385,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_SmartcardCertificate, 7, "FreeRDP_SmartcardCertificate" },
 	{ FreeRDP_SmartcardPrivateKey, 7, "FreeRDP_SmartcardPrivateKey" },
 	{ FreeRDP_SspiModule, 7, "FreeRDP_SspiModule" },
+	{ FreeRDP_SspiSecurityPackageName, 7, "FreeRDP_SspiSecurityPackageName" },
 	{ FreeRDP_TargetNetAddress, 7, "FreeRDP_TargetNetAddress" },
 	{ FreeRDP_TransportDumpFile, 7, "FreeRDP_TransportDumpFile" },
 	{ FreeRDP_Username, 7, "FreeRDP_Username" },

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -250,19 +250,26 @@ static SECURITY_STATUS nla_update_package_name(rdpNla* nla)
 	}
 
 	char* securityPackageName = NULL;
+#ifdef UNICODE
 	if (nla->settings->SspiSecurityPackageName)
 	{
-	#ifdef UNICODE
 		ConvertToUnicode(CP_UTF8, 0, nla->settings->SspiSecurityPackageName, -1, &securityPackageName, 0);
-	#else
+	}
+	else
+	{
+		securityPackageName = _wcsdup(NLA_PKG_NAME);
+	}
+#else
+	if (nla->settings->SspiSecurityPackageName)
+	{
 		securityPackageName = _strdup(nla->settings->SspiSecurityPackageName);
-	#endif
 	}
 	else
 	{
 		securityPackageName = _strdup(NLA_PKG_NAME);
 	}
-	status = nla->table->QuerySecurityPackageInfo(securityPackageName, &pPackageInfo);
+#endif
+	status = nla->table->QuerySecurityPackageInfo(NLA_PKG_NAME, &pPackageInfo);
 
 	if (status != SEC_E_OK)
 	{
@@ -1104,18 +1111,25 @@ static int nla_client_init(rdpNla* nla)
 	         nla->packageName, nla->cbMaxToken);
 
 	char* securityPackageName = NULL;
+#ifdef UNICODE
 	if (nla->settings->SspiSecurityPackageName)
 	{
-	#ifdef UNICODE
 		ConvertToUnicode(CP_UTF8, 0, nla->settings->SspiSecurityPackageName, -1, &securityPackageName, 0);
-	#else
+	}
+	else
+	{
+		securityPackageName = _wcsdup(NLA_PKG_NAME);
+	}
+#else
+	if (nla->settings->SspiSecurityPackageName)
+	{
 		securityPackageName = _strdup(nla->settings->SspiSecurityPackageName);
-	#endif
 	}
 	else
 	{
 		securityPackageName = _strdup(NLA_PKG_NAME);
 	}
+#endif
 	nla->status = nla->table->AcquireCredentialsHandle(NULL, securityPackageName, SECPKG_CRED_OUTBOUND,
 	                                                   NULL, nla->identityPtr, NULL, NULL,
 	                                                   &nla->credentials, &nla->expiration);

--- a/libfreerdp/core/nla.c
+++ b/libfreerdp/core/nla.c
@@ -269,7 +269,7 @@ static SECURITY_STATUS nla_update_package_name(rdpNla* nla)
 		securityPackageName = _strdup(NLA_PKG_NAME);
 	}
 #endif
-	status = nla->table->QuerySecurityPackageInfo(NLA_PKG_NAME, &pPackageInfo);
+	status = nla->table->QuerySecurityPackageInfo(securityPackageName, &pPackageInfo);
 
 	if (status != SEC_E_OK)
 	{

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -394,6 +394,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_SmartcardCertificate,
 	FreeRDP_SmartcardPrivateKey,
 	FreeRDP_SspiModule,
+	FreeRDP_SspiSecurityPackageName,
 	FreeRDP_TargetNetAddress,
 	FreeRDP_TransportDumpFile,
 	FreeRDP_Username,


### PR DESCRIPTION
I've added a new FreeRDP CLI option `-sspi-security-package` that specifies what security package to use from the loaded sspi module. For example, if we always want to use Kerberos we can achieve it using `-sspi-security-package Kerberos` (`/sspi-security-package:Kerberos`).

This option is not required. If the user omits it then FreeRDP will use the default value: `Negotiate`