### PR TITLE
Add Negotiate SSPI authentication module filtering

### DIFF
--- a/client/common/cmdline.c
+++ b/client/common/cmdline.c
@@ -3191,6 +3191,12 @@ int freerdp_client_settings_parse_command_line_arguments(rdpSettings* settings, 
 		{
 			settings->AuthenticationOnly = enable;
 		}
+		CommandLineSwitchCase(arg, "auth-pkg-list")
+		{
+			if (!freerdp_settings_set_string(settings, FreeRDP_AuthenticationPackageList,
+			                                 arg->Value))
+				return COMMAND_LINE_ERROR_MEMORY;
+		}
 		CommandLineSwitchCase(arg, "auto-reconnect")
 		{
 			settings->AutoReconnectionEnabled = enable;

--- a/client/common/cmdline.h
+++ b/client/common/cmdline.h
@@ -58,6 +58,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Audio output mode" },
 	{ "auth-only", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
 	  "Authenticate only" },
+	{ "auth-pkg-list", COMMAND_LINE_VALUE_REQUIRED, "<!ntlm,kerberos>", NULL, NULL, -1, NULL,
+	  "Authentication package filter (comma-separated list, use '!' to exclude" },
 	{ "authentication", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueTrue, NULL, -1, NULL,
 	  "Authentication (experimental)" },
 	{ "auto-reconnect", COMMAND_LINE_VALUE_BOOL, NULL, BoolValueFalse, NULL, -1, NULL,
@@ -225,8 +227,8 @@ static const COMMAND_LINE_ARGUMENT_A global_cmd_args[] = {
 	  "Send unicode symbols, e.g. use the local keyboard map. ATTENTION: Does not work with every "
 	  "RDP server!" },
 	{ "kerberos", COMMAND_LINE_VALUE_REQUIRED,
-	  "[lifetime:<time>,start-time:<time>,renewable-lifetime:<time>,cache:<path>,armor:<path>,"
-	  "pkinit-anchors:<path>,pkcs11-module:<name>]",
+	  "[kdc-url:<url>,lifetime:<time>,start-time:<time>,renewable-lifetime:<time>,cache:<path>,"
+	  "armor:<path>,pkinit-anchors:<path>,pkcs11-module:<name>]",
 	  NULL, NULL, -1, NULL, "Kerberos options" },
 	{ "load-balance-info", COMMAND_LINE_VALUE_REQUIRED, "<info-string>", NULL, NULL, -1, NULL,
 	  "Load balance info" },

--- a/include/freerdp/settings.h
+++ b/include/freerdp/settings.h
@@ -641,6 +641,7 @@ typedef struct
 #define FreeRDP_TLSMinVersion (1107)
 #define FreeRDP_TLSMaxVersion (1108)
 #define FreeRDP_TlsSecretsFile (1109)
+#define FreeRDP_AuthenticationPackageList (1110)
 #define FreeRDP_MstscCookieMode (1152)
 #define FreeRDP_CookieMaxLength (1153)
 #define FreeRDP_PreconnectionId (1154)
@@ -1129,7 +1130,8 @@ struct rdp_settings
 	ALIGN64 UINT16 TLSMinVersion;              /* 1107 */
 	ALIGN64 UINT16 TLSMaxVersion;              /* 1108 */
 	ALIGN64 char* TlsSecretsFile;              /* 1109 */
-	UINT64 padding1152[1152 - 1110];           /* 1110 */
+	ALIGN64 char* AuthenticationPackageList;   /* 1110 */
+	UINT64 padding1152[1152 - 1111];           /* 1111 */
 
 	/* Connection Cookie */
 	ALIGN64 BOOL MstscCookieMode;      /* 1152 */

--- a/libfreerdp/common/settings_getters.c
+++ b/libfreerdp/common/settings_getters.c
@@ -2372,6 +2372,9 @@ const char* freerdp_settings_get_string(const rdpSettings* settings, size_t id)
 		case FreeRDP_AssistanceFile:
 			return settings->AssistanceFile;
 
+		case FreeRDP_AuthenticationPackageList:
+			return settings->AuthenticationPackageList;
+
 		case FreeRDP_AuthenticationServiceClass:
 			return settings->AuthenticationServiceClass;
 
@@ -2635,6 +2638,9 @@ char* freerdp_settings_get_string_writable(rdpSettings* settings, size_t id)
 
 		case FreeRDP_AssistanceFile:
 			return settings->AssistanceFile;
+
+		case FreeRDP_AuthenticationPackageList:
+			return settings->AuthenticationPackageList;
 
 		case FreeRDP_AuthenticationServiceClass:
 			return settings->AuthenticationServiceClass;
@@ -2909,6 +2915,9 @@ BOOL freerdp_settings_set_string_(rdpSettings* settings, size_t id, const char* 
 
 		case FreeRDP_AssistanceFile:
 			return update_string(&settings->AssistanceFile, cnv.cc, len, cleanup);
+
+		case FreeRDP_AuthenticationPackageList:
+			return update_string(&settings->AuthenticationPackageList, cnv.cc, len, cleanup);
 
 		case FreeRDP_AuthenticationServiceClass:
 			return update_string(&settings->AuthenticationServiceClass, cnv.cc, len, cleanup);

--- a/libfreerdp/common/settings_str.c
+++ b/libfreerdp/common/settings_str.c
@@ -317,6 +317,7 @@ static const struct settings_str_entry settings_map[] = {
 	{ FreeRDP_AllowedTlsCiphers, 7, "FreeRDP_AllowedTlsCiphers" },
 	{ FreeRDP_AlternateShell, 7, "FreeRDP_AlternateShell" },
 	{ FreeRDP_AssistanceFile, 7, "FreeRDP_AssistanceFile" },
+	{ FreeRDP_AuthenticationPackageList, 7, "FreeRDP_AuthenticationPackageList" },
 	{ FreeRDP_AuthenticationServiceClass, 7, "FreeRDP_AuthenticationServiceClass" },
 	{ FreeRDP_BitmapCachePersistFile, 7, "FreeRDP_BitmapCachePersistFile" },
 	{ FreeRDP_CardName, 7, "FreeRDP_CardName" },

--- a/libfreerdp/core/peer.c
+++ b/libfreerdp/core/peer.c
@@ -593,7 +593,8 @@ static int peer_recv_callback_internal(rdpTransport* transport, wStream* s, void
 				if (SelectedProtocol & PROTOCOL_HYBRID)
 				{
 					SEC_WINNT_AUTH_IDENTITY* identity = nego_get_identity(rdp->nego);
-					sspi_CopyAuthIdentity(&client->identity, identity);
+					sspi_CopyAuthIdentity(&client->identity,
+					                      (const SEC_WINNT_AUTH_IDENTITY_INFO*)identity);
 					IFCALLRET(client->Logon, client->authenticated, client, &client->identity,
 					          TRUE);
 					nego_free_nla(rdp->nego);

--- a/libfreerdp/core/test/settings_property_lists.h
+++ b/libfreerdp/core/test/settings_property_lists.h
@@ -326,6 +326,7 @@ static const size_t string_list_indices[] = {
 	FreeRDP_AllowedTlsCiphers,
 	FreeRDP_AlternateShell,
 	FreeRDP_AssistanceFile,
+	FreeRDP_AuthenticationPackageList,
 	FreeRDP_AuthenticationServiceClass,
 	FreeRDP_BitmapCachePersistFile,
 	FreeRDP_CardName,

--- a/winpr/include/winpr/sspi.h
+++ b/winpr/include/winpr/sspi.h
@@ -675,7 +675,6 @@ typedef struct
 
 typedef struct
 {
-	/* TSPasswordCreds */
 	UINT16* User;
 	UINT32 UserLength;
 	UINT16* Domain;
@@ -687,7 +686,6 @@ typedef struct
 
 typedef struct
 {
-	/* TSPasswordCreds */
 	BYTE* User;
 	UINT32 UserLength;
 	BYTE* Domain;
@@ -697,17 +695,15 @@ typedef struct
 	UINT32 Flags;
 } SEC_WINNT_AUTH_IDENTITY_A, *PSEC_WINNT_AUTH_IDENTITY_A;
 
-typedef struct
-{
-	/* TSPasswordCreds */
-	UINT16* User;
-	UINT32 UserLength;
-	UINT16* Domain;
-	UINT32 DomainLength;
-	UINT16* Password;
-	UINT32 PasswordLength;
-	UINT32 Flags;
-} SEC_WINNT_AUTH_IDENTITY;
+// Always define SEC_WINNT_AUTH_IDENTITY to SEC_WINNT_AUTH_IDENTITY_W
+
+#ifdef UNICODE
+#define SEC_WINNT_AUTH_IDENTITY SEC_WINNT_AUTH_IDENTITY_W
+#define PSEC_WINNT_AUTH_IDENTITY PSEC_WINNT_AUTH_IDENTITY_W
+#else
+#define SEC_WINNT_AUTH_IDENTITY SEC_WINNT_AUTH_IDENTITY_W
+#define PSEC_WINNT_AUTH_IDENTITY PSEC_WINNT_AUTH_IDENTITY_W
+#endif
 
 #endif /* _AUTH_IDENTITY_DEFINED */
 
@@ -725,7 +721,7 @@ typedef struct
 	UINT16* Password;
 	UINT32 PasswordLength;
 	UINT32 Flags;
-	BYTE* PackageList;
+	UINT16* PackageList;
 	UINT32 PackageListLength;
 } SEC_WINNT_AUTH_IDENTITY_EXW, *PSEC_WINNT_AUTH_IDENTITY_EXW;
 
@@ -744,7 +740,73 @@ typedef struct
 	UINT32 PackageListLength;
 } SEC_WINNT_AUTH_IDENTITY_EXA, *PSEC_WINNT_AUTH_IDENTITY_EXA;
 
+#ifdef UNICODE
+#define SEC_WINNT_AUTH_IDENTITY_EX SEC_WINNT_AUTH_IDENTITY_EXW
+#define PSEC_WINNT_AUTH_IDENTITY_EX PSEC_WINNT_AUTH_IDENTITY_EXW
+#else
+#define SEC_WINNT_AUTH_IDENTITY_EX SEC_WINNT_AUTH_IDENTITY_EXA
+#define PSEC_WINNT_AUTH_IDENTITY_EX PSEC_WINNT_AUTH_IDENTITY_EXA
+#endif
+
 #endif /* SEC_WINNT_AUTH_IDENTITY_VERSION */
+
+#ifndef SEC_WINNT_AUTH_IDENTITY_VERSION_2
+#define SEC_WINNT_AUTH_IDENTITY_VERSION_2 0x201
+
+typedef struct _SEC_WINNT_AUTH_IDENTITY_EX2
+{
+	UINT32 Version;
+	UINT16 cbHeaderLength;
+	UINT32 cbStructureLength;
+	UINT32 UserOffset;
+	UINT16 UserLength;
+	UINT32 DomainOffset;
+	UINT16 DomainLength;
+	UINT32 PackedCredentialsOffset;
+	UINT16 PackedCredentialsLength;
+	UINT32 Flags;
+	UINT32 PackageListOffset;
+	UINT16 PackageListLength;
+} SEC_WINNT_AUTH_IDENTITY_EX2, *PSEC_WINNT_AUTH_IDENTITY_EX2;
+
+#endif /* SEC_WINNT_AUTH_IDENTITY_VERSION_2 */
+
+#ifndef _AUTH_IDENTITY_INFO_DEFINED
+#define _AUTH_IDENTITY_INFO_DEFINED
+
+// https://docs.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_winnt_auth_identity_info
+
+typedef union _SEC_WINNT_AUTH_IDENTITY_INFO
+{
+	SEC_WINNT_AUTH_IDENTITY_EXW AuthIdExw;
+	SEC_WINNT_AUTH_IDENTITY_EXA AuthIdExa;
+	SEC_WINNT_AUTH_IDENTITY_A AuthId_a;
+	SEC_WINNT_AUTH_IDENTITY_W AuthId_w;
+	SEC_WINNT_AUTH_IDENTITY_EX2 AuthIdEx2;
+} SEC_WINNT_AUTH_IDENTITY_INFO, *PSEC_WINNT_AUTH_IDENTITY_INFO;
+
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_PROCESS_ENCRYPTED 0x10
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SYSTEM_PROTECTED 0x20
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_USER_PROTECTED 0x40
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SYSTEM_ENCRYPTED 0x80
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_RESERVED 0x10000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_NULL_USER 0x20000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_NULL_DOMAIN 0x40000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_ID_PROVIDER 0x80000
+
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_USE_MASK 0xFF000000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_CREDPROV_DO_NOT_SAVE 0x80000000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_SAVE_CRED_CHECKED 0x40000000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_NO_CHECKBOX 0x20000000
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_CREDPROV_DO_NOT_LOAD 0x10000000
+
+#define SEC_WINNT_AUTH_IDENTITY_FLAGS_VALID_SSPIPFC_FLAGS         \
+	(SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_CREDPROV_DO_NOT_SAVE | \
+	 SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_SAVE_CRED_CHECKED |    \
+	 SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_NO_CHECKBOX |          \
+	 SEC_WINNT_AUTH_IDENTITY_FLAGS_SSPIPFC_CREDPROV_DO_NOT_LOAD)
+
+#endif /* _AUTH_IDENTITY_INFO_DEFINED */
 
 #if defined(__clang__)
 #pragma clang diagnostic pop
@@ -817,9 +879,9 @@ typedef struct
 
 typedef struct
 {
-	SEC_WINNT_AUTH_IDENTITY identity;
-	SEC_WINPR_NTLM_SETTINGS ntlmSettings;
-	SEC_WINPR_KERBEROS_SETTINGS kerberosSettings;
+	SEC_WINNT_AUTH_IDENTITY_EXW identity;
+	SEC_WINPR_NTLM_SETTINGS* ntlmSettings;
+	SEC_WINPR_KERBEROS_SETTINGS* kerberosSettings;
 } SEC_WINNT_AUTH_IDENTITY_WINPR;
 
 #define SECBUFFER_VERSION 0
@@ -1357,8 +1419,26 @@ extern "C"
 	WINPR_API int sspi_SetAuthIdentityWithUnicodePassword(SEC_WINNT_AUTH_IDENTITY* identity,
 	                                                      const char* user, const char* domain,
 	                                                      LPWSTR password, ULONG passwordLength);
+	WINPR_API UINT32 sspi_GetAuthIdentityVersion(void* identity);
+	WINPR_API UINT32 sspi_GetAuthIdentityFlags(void* identity);
+	WINPR_API BOOL sspi_GetAuthIdentityUserDomainW(void* identity, WCHAR** pUser,
+	                                               UINT32* pUserLength, WCHAR** pDomain,
+	                                               UINT32* pDomainLength);
+	WINPR_API BOOL sspi_GetAuthIdentityUserDomainA(void* identity, char** pUser,
+	                                               UINT32* pUserLength, char** pDomain,
+	                                               UINT32* pDomainLength);
+	WINPR_API BOOL sspi_GetAuthIdentityPasswordW(void* identity, WCHAR** pPassword,
+	                                             UINT32* pPasswordLength);
+	WINPR_API BOOL sspi_GetAuthIdentityPasswordA(void* identity, char** pPassword,
+	                                             UINT32* pPasswordLength);
+	WINPR_API BOOL sspi_CopyAuthIdentityFieldsA(const SEC_WINNT_AUTH_IDENTITY_INFO* identity,
+	                                            char** pUser, char** pDomain, char** pPassword);
+	WINPR_API BOOL sspi_CopyAuthIdentityFieldsW(const SEC_WINNT_AUTH_IDENTITY_INFO* identity,
+	                                            WCHAR** pUser, WCHAR** pDomain, WCHAR** pPassword);
+	WINPR_API BOOL sspi_CopyAuthPackageListA(const SEC_WINNT_AUTH_IDENTITY_INFO* identity,
+	                                         char** pPackageList);
 	WINPR_API int sspi_CopyAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity,
-	                                    const SEC_WINNT_AUTH_IDENTITY* srcIdentity);
+	                                    const SEC_WINNT_AUTH_IDENTITY_INFO* srcIdentity);
 
 	WINPR_API void sspi_FreeAuthIdentity(SEC_WINNT_AUTH_IDENTITY* identity);
 

--- a/winpr/libwinpr/sspi/Kerberos/kerberos.c
+++ b/winpr/libwinpr/sspi/Kerberos/kerberos.c
@@ -178,10 +178,9 @@ static SECURITY_STATUS SEC_ENTRY kerberos_AcquireCredentialsHandleA(
     PTimeStamp ptsExpiry)
 {
 #ifdef WITH_GSSAPI
-	SEC_WINNT_AUTH_IDENTITY* identity = pAuthData;
 	SEC_WINPR_KERBEROS_SETTINGS* krb_settings = NULL;
 	KRB_CREDENTIALS* credentials = NULL;
-	krb5_error_code rv;
+	krb5_error_code rv = 0;
 	krb5_context ctx = NULL;
 	krb5_ccache ccache = NULL;
 	krb5_keytab keytab = NULL;
@@ -189,32 +188,23 @@ static SECURITY_STATUS SEC_ENTRY kerberos_AcquireCredentialsHandleA(
 	krb5_deltat start_time = 0;
 	krb5_principal principal = NULL;
 	krb5_init_creds_context creds_ctx = NULL;
-	BOOL is_unicode = FALSE;
 	char* domain = NULL;
 	char* username = NULL;
 	char* password = NULL;
 	const char* fallback_ccache = "MEMORY:";
 
-	if (identity)
+	if (pAuthData)
 	{
-		if (identity->Flags & SEC_WINNT_AUTH_IDENTITY_EXTENDED)
-			krb_settings = &((SEC_WINNT_AUTH_IDENTITY_WINPR*)identity)->kerberosSettings;
+		UINT32 identityFlags = sspi_GetAuthIdentityFlags(pAuthData);
 
-		if (identity->Flags & SEC_WINNT_AUTH_IDENTITY_UNICODE)
+		if (identityFlags & SEC_WINNT_AUTH_IDENTITY_EXTENDED)
+			krb_settings = ((SEC_WINNT_AUTH_IDENTITY_WINPR*)pAuthData)->kerberosSettings;
+
+		if (!sspi_CopyAuthIdentityFieldsA((const SEC_WINNT_AUTH_IDENTITY_INFO*)pAuthData, &username,
+		                                  &domain, &password))
 		{
-			is_unicode = TRUE;
-			ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)identity->Domain, identity->DomainLength,
-			                   &domain, 0, NULL, NULL);
-			ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)identity->User, identity->UserLength, &username,
-			                   0, NULL, NULL);
-			ConvertFromUnicode(CP_UTF8, 0, (WCHAR*)identity->Password, identity->PasswordLength,
-			                   &password, 0, NULL, NULL);
-		}
-		else
-		{
-			domain = (char*)identity->Domain;
-			username = (char*)identity->User;
-			password = (char*)identity->Password;
+			WLog_ERR(TAG, "Failed to copy auth identity fields");
+			goto cleanup;
 		}
 
 		if (!pszPrincipal)
@@ -336,15 +326,13 @@ cleanup:
 	if (rv)
 		kerberos_log_msg(ctx, rv);
 
-	if (is_unicode)
-	{
-		if (domain)
-			free(domain);
-		if (username)
-			free(username);
-		if (password)
-			free(password);
-	}
+	if (domain)
+		free(domain);
+	if (username)
+		free(username);
+	if (password)
+		free(password);
+
 	if (principal)
 		krb5_free_principal(ctx, principal);
 	if (creds_ctx)

--- a/winpr/libwinpr/sspi/NTLM/ntlm.c
+++ b/winpr/libwinpr/sspi/NTLM/ntlm.c
@@ -297,7 +297,6 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcquireCredentialsHandleW(
     PTimeStamp ptsExpiry)
 {
 	SSPI_CREDENTIALS* credentials;
-	SEC_WINNT_AUTH_IDENTITY* identity;
 	SEC_WINPR_NTLM_SETTINGS* settings = NULL;
 
 	if ((fCredentialUse != SECPKG_CRED_OUTBOUND) && (fCredentialUse != SECPKG_CRED_INBOUND) &&
@@ -315,13 +314,15 @@ static SECURITY_STATUS SEC_ENTRY ntlm_AcquireCredentialsHandleW(
 	credentials->pGetKeyFn = pGetKeyFn;
 	credentials->pvGetKeyArgument = pvGetKeyArgument;
 
-	identity = (SEC_WINNT_AUTH_IDENTITY*)pAuthData;
-
-	if (identity)
+	if (pAuthData)
 	{
-		sspi_CopyAuthIdentity(&(credentials->identity), identity);
-		if (identity->Flags & SEC_WINNT_AUTH_IDENTITY_EXTENDED)
-			settings = &((SEC_WINNT_AUTH_IDENTITY_WINPR*)pAuthData)->ntlmSettings;
+		UINT32 identityFlags = sspi_GetAuthIdentityFlags(pAuthData);
+
+		sspi_CopyAuthIdentity(&(credentials->identity),
+		                      (const SEC_WINNT_AUTH_IDENTITY_INFO*)pAuthData);
+
+		if (identityFlags & SEC_WINNT_AUTH_IDENTITY_EXTENDED)
+			settings = ((SEC_WINNT_AUTH_IDENTITY_WINPR*)pAuthData)->ntlmSettings;
 	}
 
 	if (settings)

--- a/winpr/libwinpr/sspi/Negotiate/negotiate.c
+++ b/winpr/libwinpr/sspi/Negotiate/negotiate.c
@@ -243,7 +243,49 @@ static BOOL negotiate_get_dword(HKEY hKey, const char* subkey, DWORD* pdwValue)
 	return TRUE;
 }
 
-static BOOL negotiate_get_config(BOOL* kerberos, BOOL* ntlm)
+static BOOL negotiate_get_config_from_auth_package_list(void* pAuthData, BOOL* kerberos, BOOL* ntlm)
+{
+	char* tok_ctx = NULL;
+	char* tok_ptr = NULL;
+	char* PackageList = NULL;
+
+	if (!sspi_CopyAuthPackageListA((const SEC_WINNT_AUTH_IDENTITY_INFO*)pAuthData, &PackageList))
+		return FALSE;
+
+	tok_ptr = strtok_s(PackageList, ",", &tok_ctx);
+
+	while (tok_ptr)
+	{
+		char* PackageName = tok_ptr;
+		BOOL PackageInclude = TRUE;
+
+		if (PackageName[0] == '!')
+		{
+			PackageName = &PackageName[1];
+			PackageInclude = FALSE;
+		}
+
+		if (!_stricmp(PackageName, "ntlm"))
+		{
+			*ntlm = PackageInclude;
+		}
+		else if (!_stricmp(PackageName, "kerberos"))
+		{
+			*kerberos = PackageInclude;
+		}
+		else
+		{
+			WLog_WARN(TAG, "Unknown authentication package name: %s", PackageName);
+		}
+
+		tok_ptr = strtok_s(NULL, ",", &tok_ctx);
+	}
+
+	free(PackageList);
+	return TRUE;
+}
+
+static BOOL negotiate_get_config(void* pAuthData, BOOL* kerberos, BOOL* ntlm)
 {
 	HKEY hKey = NULL;
 	LONG rc;
@@ -257,6 +299,11 @@ static BOOL negotiate_get_config(BOOL* kerberos, BOOL* ntlm)
 	*ntlm = FALSE;
 #endif
 	*kerberos = TRUE;
+
+	if (negotiate_get_config_from_auth_package_list(pAuthData, kerberos, ntlm))
+	{
+		return TRUE; // use explicit authentication package list
+	}
 
 	rc = RegOpenKeyExA(HKEY_LOCAL_MACHINE, NEGO_REG_KEY, 0, KEY_READ | KEY_WOW64_64KEY, &hKey);
 	if (rc == ERROR_SUCCESS)
@@ -1280,7 +1327,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleW(
 {
 	BOOL kerberos, ntlm;
 
-	if (!negotiate_get_config(&kerberos, &ntlm))
+	if (!negotiate_get_config(pAuthData, &kerberos, &ntlm))
 		return SEC_E_INTERNAL_ERROR;
 
 	MechCred* creds = calloc(MECH_COUNT, sizeof(MechCred));
@@ -1321,7 +1368,7 @@ static SECURITY_STATUS SEC_ENTRY negotiate_AcquireCredentialsHandleA(
 {
 	BOOL kerberos, ntlm;
 
-	if (!negotiate_get_config(&kerberos, &ntlm))
+	if (!negotiate_get_config(pAuthData, &kerberos, &ntlm))
 		return SEC_E_INTERNAL_ERROR;
 
 	MechCred* creds = calloc(MECH_COUNT, sizeof(MechCred));


### PR DESCRIPTION
Add AuthenticationPackageList setting, /auth-pkg-list command-line option
Add missing SEC_WINNT_AUTH_IDENTITY_INFO|EX|EX2 structure definitions
Use SEC_WINNT_AUTH_IDENTITY_WINPR as temporary data transfer structure
Safely accept SEC_WINNT_AUTH_IDENTITY_INFO in AcquireCredentialsHandle
Use SEC_WINNT_AUTH_IDENTITY_EX (+PackageList) in AcquireCredentialsHandle
Use PackageList field if available in Negotiate SSPI module to filter subpackages
Properly SecurityFunctionTable version 3 from Windows SSPI (version 1 by default)
Add various SSPI helpers to deal with various identity structures and conversions
The SEC_WINNT_AUTH_IDENTITY_EX.PackageList field is the only way to filter Negotiate SSPI subpackages with Windows SSPI. I have some some testing on Windows [to observe the final behavior in Wireshark](https://twitter.com/awakecoding/status/1577711426529267712):

No package list:
MechType: 1.2.840.48018.1.2.2 (MS KRB5 - Microsoft Kerberos 5)
MechType: 1.2.840.113554.1.2.2 (KRB5 - Kerberos 5)
MechType: 1.3.6.1.4.1.311.2.2.30 (NEGOEX - SPNEGO Extended Negotiation Security Mechanism)
MechType: 1.3.6.1.4.1.311.2.2.10 (NTLMSSP - Microsoft NTLM Security Support Provider)

/auth-pkg-list:!ntlm
MechType: 1.2.840.48018.1.2.2 (MS KRB5 - Microsoft Kerberos 5)
MechType: 1.2.840.113554.1.2.2 (KRB5 - Kerberos 5)
MechType: 1.3.6.1.4.1.311.2.2.30 (NEGOEX - SPNEGO Extended Negotiation Security Mechanism)

/auth-pkg-list:!kerberos
MechType: 1.3.6.1.4.1.311.2.2.30 (NEGOEX - SPNEGO Extended Negotiation Security Mechanism)
MechType: 1.3.6.1.4.1.311.2.2.10 (NTLMSSP - Microsoft NTLM Security Support Provider)

The [PackageList](https://learn.microsoft.com/en-us/windows/win32/api/sspi/ns-sspi-sec_winnt_auth_identity_exw) is documented to be:

A Unicode or ANSI string that contains a comma-separated list of names of security packages that are available when using the Negotiate provider. Set this to "!ntlm" to specify that the NTLM package is not to be used.

"ntlm,kerberos" is broken with Windows SSPI, as it results in raw NTLM without SPNEGO. Surprisingly, "kerberos,ntlm" works as expected: an allow list of "Kerberos" and "NTLM". In the WinPR Negotiate SSPI module, I just treat is as a comma-separated list of modules, where "!" excludes the module, and the lack of "!" includes the module. However, for better compatibility with Windows SSPI, it is better to only exclude individual packages.

On my side, I intend to give user control over "Windows Authentication" in Remote Desktop Manager with three settings:

Negotiate (try Kerberos, fallback to NTLM)
NTLM (downgrade to NTLM, don't try Kerberos)
Kerberos (try Kerberos, don't fallback to NTLM)
The equivalent "AuthenticationPackageList" setting for each will be:

Negotiate:
NTLM: !kerberos
Kerberos: !ntlm
Which will be sufficient for what I want to achieve in terms of feature with FreeRDP, and it'll still be usable by everyone through the command-line interface, so win-win for everybody. I will modify [sspi-rs](https://github.com/Devolutions/sspi-rs) to accept SEC_WINNT_AUTH_IDENTITY_EX.PackageList as well.