### PR TITLE
feat(nla): add rdp_nla.innerErrorCode field in order to propogate a Kerberos error code back to the client.

### DIFF
--- a/libfreerdp/core/credssp_auth.h
+++ b/libfreerdp/core/credssp_auth.h
@@ -40,7 +40,7 @@ FREERDP_LOCAL BOOL credssp_auth_setup_client(rdpCredsspAuth* auth, const char* t
                                              const char* pkinit);
 FREERDP_LOCAL BOOL credssp_auth_setup_server(rdpCredsspAuth* auth);
 FREERDP_LOCAL void credssp_auth_set_flags(rdpCredsspAuth* auth, ULONG flags);
-FREERDP_LOCAL int credssp_auth_authenticate(rdpCredsspAuth* auth);
+FREERDP_LOCAL int credssp_auth_authenticate(rdpCredsspAuth* auth, int* innerErrorCode);
 FREERDP_LOCAL BOOL credssp_auth_encrypt(rdpCredsspAuth* auth, const SecBuffer* plaintext,
                                         SecBuffer* ciphertext, size_t* signature_length,
                                         ULONG sequence);


### PR DESCRIPTION
FreeRDP just returns -1 and doesn't inform the user exactly what error occurred. This new error code helps to debug Kerberos issues during an authorization
